### PR TITLE
Song score download and oauth2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,10 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-jose</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-client</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,10 +28,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-r2dbc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
@@ -40,7 +36,11 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Postgres -->
+        <!-- DB -->
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-r2dbc</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.r2dbc</groupId>
             <artifactId>r2dbc-postgresql</artifactId>

--- a/src/main/java/org/cancogenvirusseq/muse/api/ApiController.java
+++ b/src/main/java/org/cancogenvirusseq/muse/api/ApiController.java
@@ -92,9 +92,8 @@ public class ApiController implements ApiDefinition {
 
   public ResponseEntity<Flux<DataBuffer>> download(
       @NonNull @Valid @RequestBody DownloadRequest downloadRequest) {
-    val fileName = downloadRequest.getStudyId() + FASTA_FILE_EXTENSION;
     return ResponseEntity.ok()
-        .header(CONTENT_DISPOSITION_HEADER, format("attachment; filename=%s", fileName))
+        .header(CONTENT_DISPOSITION_HEADER, format("attachment; filename=%s", downloadRequest.getStudyId() + FASTA_FILE_EXTENSION))
         .body(downloadsService.download(downloadRequest));
   }
 

--- a/src/main/java/org/cancogenvirusseq/muse/api/ApiController.java
+++ b/src/main/java/org/cancogenvirusseq/muse/api/ApiController.java
@@ -18,7 +18,9 @@
 
 package org.cancogenvirusseq.muse.api;
 
-import java.nio.ByteBuffer;
+import static java.lang.String.format;
+import static org.cancogenvirusseq.muse.components.FastaFileProcessor.FASTA_FILE_EXTENSION;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -26,11 +28,13 @@ import javax.validation.Valid;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.cancogenvirusseq.muse.api.model.*;
 import org.cancogenvirusseq.muse.service.DownloadsService;
 import org.cancogenvirusseq.muse.service.SubmissionService;
 import org.cancogenvirusseq.muse.service.UploadService;
 import org.cancogenvirusseq.muse.utils.SecurityContextWrapper;
+import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
@@ -49,6 +53,8 @@ public class ApiController implements ApiDefinition {
   private final SubmissionService submissionService;
   private final UploadService uploadService;
   private final DownloadsService downloadsService;
+
+  private static final String CONTENT_DISPOSITION_HEADER = "Content-Disposition";
 
   @GetMapping("/submissions")
   public Mono<ResponseEntity<EntityListResponse<SubmissionDTO>>> getSubmissions(
@@ -84,10 +90,12 @@ public class ApiController implements ApiDefinition {
         .transform(this::listResponseTransform);
   }
 
-  @PostMapping("/download")
-  public Mono<ResponseEntity<Flux<ByteBuffer>>> download(
+  public ResponseEntity<Flux<DataBuffer>> download(
       @NonNull @Valid @RequestBody DownloadRequest downloadRequest) {
-    return downloadsService.download(downloadRequest).map(this::respondOk);
+    val fileName = downloadRequest.getStudyId() + FASTA_FILE_EXTENSION;
+    return ResponseEntity.ok()
+        .header(CONTENT_DISPOSITION_HEADER, format("attachment; filename=%s", fileName))
+        .body(downloadsService.download(downloadRequest));
   }
 
   @ExceptionHandler

--- a/src/main/java/org/cancogenvirusseq/muse/api/ApiDefinition.java
+++ b/src/main/java/org/cancogenvirusseq/muse/api/ApiDefinition.java
@@ -19,10 +19,10 @@
 package org.cancogenvirusseq.muse.api;
 
 import io.swagger.annotations.*;
-import java.nio.ByteBuffer;
 import java.util.UUID;
 import javax.validation.Valid;
 import org.cancogenvirusseq.muse.api.model.*;
+import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -173,6 +173,5 @@ public interface ApiDefinition {
       produces = MediaType.APPLICATION_OCTET_STREAM_VALUE,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       method = RequestMethod.GET)
-  Mono<ResponseEntity<Flux<ByteBuffer>>> download(
-      @Valid @RequestBody DownloadRequest downloadRequest);
+  ResponseEntity<Flux<DataBuffer>> download(@Valid @RequestBody DownloadRequest downloadRequest);
 }

--- a/src/main/java/org/cancogenvirusseq/muse/api/model/DownloadRequest.java
+++ b/src/main/java/org/cancogenvirusseq/muse/api/model/DownloadRequest.java
@@ -28,5 +28,6 @@ import lombok.NonNull;
 @AllArgsConstructor
 @NoArgsConstructor
 public class DownloadRequest {
+  @NonNull private String studyId;
   @NonNull private List<String> analysisIds;
 }

--- a/src/main/java/org/cancogenvirusseq/muse/service/DownloadsService.java
+++ b/src/main/java/org/cancogenvirusseq/muse/service/DownloadsService.java
@@ -18,15 +18,40 @@
 
 package org.cancogenvirusseq.muse.service;
 
-import java.nio.ByteBuffer;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.cancogenvirusseq.muse.api.model.DownloadRequest;
+import org.cancogenvirusseq.muse.components.SongScoreClient;
+import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class DownloadsService {
-  public Mono<Flux<ByteBuffer>> download(DownloadRequest downloadRequest) {
-    return Mono.just(Flux.empty());
+
+  final SongScoreClient songScoreClient;
+
+  public Flux<DataBuffer> download(DownloadRequest downloadRequest) {
+    val analysisIds = downloadRequest.getAnalysisIds();
+    val studyId = downloadRequest.getStudyId();
+
+    return Flux.fromIterable(analysisIds)
+        .map(UUID::fromString)
+        .flatMap(analysisId -> songScoreClient.getFileSpecFromSong(studyId, analysisId))
+        .flatMap(
+            analysisFileResponse -> {
+              val objectId = analysisFileResponse.getObjectId();
+              return songScoreClient.downloadObject(objectId);
+            })
+        .onErrorMap(
+            throwable -> {
+              throwable.printStackTrace();
+              log.error("Error occured - {}", throwable.getMessage());
+              return new Error("Internal Server Error, try again later");
+            });
   }
 }

--- a/src/main/java/org/cancogenvirusseq/muse/service/DownloadsService.java
+++ b/src/main/java/org/cancogenvirusseq/muse/service/DownloadsService.java
@@ -47,11 +47,6 @@ public class DownloadsService {
               val objectId = analysisFileResponse.getObjectId();
               return songScoreClient.downloadObject(objectId);
             })
-        .onErrorMap(
-            throwable -> {
-              throwable.printStackTrace();
-              log.error("Error occured - {}", throwable.getMessage());
-              return new Error("Internal Server Error, try again later");
-            });
+        .onErrorMap(throwable -> new Error("Internal Server Error, try again later"));
   }
 }

--- a/src/main/java/org/cancogenvirusseq/muse/service/SongScoreService.java
+++ b/src/main/java/org/cancogenvirusseq/muse/service/SongScoreService.java
@@ -57,12 +57,14 @@ public class SongScoreService {
   private Disposable createSubmitUploadDisposable() {
     return sink.asFlux()
         .flatMap(this::extractPayloadUploadAndSubFileFromEvent)
-        .flatMap(this::submitAndUploadToSongScore)
         .onErrorContinue(
-            (t, obj) -> {
-              log.error("Panic because - {}", t.getMessage());
-              log.error("Panic cause by - {}", obj);
-            })
+               (t, obj) -> {
+                   t.printStackTrace();
+                   log.error("Disposable Panic - {}", t.getMessage());
+                   log.error("Disposable Panic cause by - {}", obj);
+               })
+        .flatMap(this::submitAndUploadToSongScore)
+
         .subscribe();
   }
 

--- a/src/main/java/org/cancogenvirusseq/muse/service/SongScoreService.java
+++ b/src/main/java/org/cancogenvirusseq/muse/service/SongScoreService.java
@@ -57,18 +57,11 @@ public class SongScoreService {
   private Disposable createSubmitUploadDisposable() {
     return sink.asFlux()
         .flatMap(this::extractPayloadUploadAndSubFileFromEvent)
-        .onErrorContinue(
-               (t, obj) -> {
-                   t.printStackTrace();
-                   log.error("Disposable Panic - {}", t.getMessage());
-                   log.error("Disposable Panic cause by - {}", obj);
-               })
         .flatMap(this::submitAndUploadToSongScore)
-
         .subscribe();
   }
 
-  private Flux<Tuple3<String, Upload, SubmissionFile>> extractPayloadUploadAndSubFileFromEvent(
+  public Flux<Tuple3<String, Upload, SubmissionFile>> extractPayloadUploadAndSubFileFromEvent(
       SubmissionEvent submissionEvent) {
     val records = submissionEvent.getRecords();
     val map = submissionEvent.getSubmissionFilesMap();
@@ -103,7 +96,7 @@ public class SongScoreService {
                 }));
   }
 
-  private Mono<Upload> submitAndUploadToSongScore(Tuple3<String, Upload, SubmissionFile> tuples3) {
+  public Mono<Upload> submitAndUploadToSongScore(Tuple3<String, Upload, SubmissionFile> tuples3) {
     val payload = tuples3.getT1();
     val upload = tuples3.getT2();
     val submissionFile = tuples3.getT3();

--- a/src/main/java/org/cancogenvirusseq/muse/service/SongScoreService.java
+++ b/src/main/java/org/cancogenvirusseq/muse/service/SongScoreService.java
@@ -58,10 +58,15 @@ public class SongScoreService {
     return sink.asFlux()
         .flatMap(this::extractPayloadUploadAndSubFileFromEvent)
         .flatMap(this::submitAndUploadToSongScore)
+        .onErrorContinue(
+            (t, obj) -> {
+              log.error("Panic because - {}", t.getMessage());
+              log.error("Panic cause by - {}", obj);
+            })
         .subscribe();
   }
 
-  public Flux<Tuple3<String, Upload, SubmissionFile>> extractPayloadUploadAndSubFileFromEvent(
+  private Flux<Tuple3<String, Upload, SubmissionFile>> extractPayloadUploadAndSubFileFromEvent(
       SubmissionEvent submissionEvent) {
     val records = submissionEvent.getRecords();
     val map = submissionEvent.getSubmissionFilesMap();
@@ -96,7 +101,7 @@ public class SongScoreService {
                 }));
   }
 
-  public Mono<Upload> submitAndUploadToSongScore(Tuple3<String, Upload, SubmissionFile> tuples3) {
+  private Mono<Upload> submitAndUploadToSongScore(Tuple3<String, Upload, SubmissionFile> tuples3) {
     val payload = tuples3.getT1();
     val upload = tuples3.getT2();
     val submissionFile = tuples3.getT3();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,9 +17,9 @@ postgres:
 songScoreClient:
   songRootUrl: "http://localhost:8089/"
   scoreRootUrl: "http://localhost:8087/"
-  systemApiToken: f69b726d-d40f-4261-b105-1ec7e6bf04d5
   clientId: adminId
   clientSecret: adminSecret
+  tokenUrl: http://localhost:8081/oauth/token
 
 auth:
   jwtPublicKeyUrl: "http://localhost:8081/oauth/token/public_key"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,6 +18,8 @@ songScoreClient:
   songRootUrl: "http://localhost:8089/"
   scoreRootUrl: "http://localhost:8087/"
   systemApiToken: f69b726d-d40f-4261-b105-1ec7e6bf04d5
+  clientId: adminId
+  clientSecret: adminSecret
 
 auth:
   jwtPublicKeyUrl: "http://localhost:8081/oauth/token/public_key"


### PR DESCRIPTION
changes:
- Given a list of analysisId, DownloadService will stream the files as Flux of DataBuffers
- SongScoreClient updated to use Oauth client_credentials flow, removed api key
