### PR TITLE
health check

### DIFF
--- a/src/main/java/org/cancogenvirusseq/muse/health/UploadHealthCheck.java
+++ b/src/main/java/org/cancogenvirusseq/muse/health/UploadHealthCheck.java
@@ -1,0 +1,32 @@
+package org.cancogenvirusseq.muse.health;
+
+import org.cancogenvirusseq.muse.service.SongScoreService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UploadHealthCheck implements HealthIndicator {
+
+  private static final String MESSAGE_KEY = "Upload Disposable";
+
+  private final SongScoreService songScoreService;
+
+  @Autowired
+  public UploadHealthCheck(SongScoreService songScoreService) {
+    this.songScoreService = songScoreService;
+  }
+
+  @Override
+  public Health health() {
+    if (!songScoreService.getSubmitUploadDisposable().isDisposed()) {
+      return Health.up()
+          .withDetail(MESSAGE_KEY, "Upload disposable is running.")
+          .build(); // Healthy
+    }
+    return Health.down()
+        .withDetail(MESSAGE_KEY, "Upload disposable has stopped.")
+        .build(); // Unhealthy
+  }
+}

--- a/src/main/java/org/cancogenvirusseq/muse/health/UploadHealthCheck.java
+++ b/src/main/java/org/cancogenvirusseq/muse/health/UploadHealthCheck.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class UploadHealthCheck implements HealthIndicator {
 
-  private static final String MESSAGE_KEY = "Upload Disposable";
+  private static final String MESSAGE_KEY = "uploadDisposable";
 
   private final SongScoreService songScoreService;
 

--- a/src/main/java/org/cancogenvirusseq/muse/service/SongScoreService.java
+++ b/src/main/java/org/cancogenvirusseq/muse/service/SongScoreService.java
@@ -42,7 +42,7 @@ public class SongScoreService {
 
   private Sinks.Many<SubmissionEvent> sink = Sinks.many().unicast().onBackpressureBuffer();
 
-  private Disposable submitUploadDisposable;
+  @Getter private Disposable submitUploadDisposable;
 
   @PostConstruct
   public void init() {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,3 +27,8 @@ auth:
       - DOMAIN.READ
     write:
       - DOMAIN.WRITE
+
+management:
+  endpoint:
+    health:
+      show-details: NEVER


### PR DESCRIPTION
When setting `show-details` to `ALWAYS` in the config and disposable is down, you can see it makes the app unhealthy:

![image](https://user-images.githubusercontent.com/6350043/114044168-f92bbc80-9854-11eb-9a6e-e75efba609a8.png)
