### PR TITLE
Fixes OriginalFileName issues + Updates default values + Updates Dockercompose

### DIFF
--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       SPRING_FLYWAY_ENABLED: "true"
       SPRING_FLYWAY_LOCATIONS: "classpath:flyway/sql,classpath:db/migration"
       SPRING_PROFILES: demo, auth
-      JWT_DURATIONMS: 1800000 # expire tokens in 30 min for local testing
+      JWT_DURATIONMS: 2147483647 # expire tokens in 24.855 days (max-int ms) for local testing
     expose:
       - "8080"
     ports:
@@ -44,7 +44,6 @@ services:
     ports:
       - "8085:9000"
   score-server:
-    network_mode: "host"
     image: overture/score-server:5.3.0
     environment:
       SPRING_PROFILES_ACTIVE: amazon,collaboratory,prod,secure,jwt
@@ -53,13 +52,13 @@ services:
       BUCKET_NAME_OBJECT: oicr.icgc.test
       BUCKET_NAME_STATE: oicr.icgc.test
       COLLABORATORY_DATA_DIRECTORY: data
-      METADATA_URL: http://localhost:8089
-      S3_ENDPOINT:  http://localhost:8085
+      METADATA_URL: http://song:8089
+      S3_ENDPOINT:  http://object-storage:8085
       S3_ACCESSKEY: minio
       S3_SECRETKEY: minio123
       S3_SIGV4ENABLED: "true"
-      AUTH_JWT_PUBLICKEYURL: http://localhost:8081/oauth/token/public_key
-      AUTH_SERVER_URL: http://localhost:8081/o/check_api_key/
+      AUTH_JWT_PUBLICKEYURL: http://ego-api:8081/oauth/token/public_key
+      AUTH_SERVER_URL: http://ego-api:8081/o/check_api_key/
       AUTH_SERVER_CLIENTID: score
       AUTH_SERVER_CLIENTSECRET: scoresecret
       AUTH_SERVER_TOKENNAME: apiKey
@@ -96,28 +95,27 @@ services:
     volumes:
       - "./song-db-init:/docker-entrypoint-initdb.d"
   song-server:
-    network_mode: "host"
     image: overture/song-server:4.5.0
     environment:
       SERVER_PORT: 8089
       SPRING_PROFILES_ACTIVE: "prod,secure,default,jwt,score-client-cred"
-      AUTH_JWT_PUBLICKEYURL: http://localhost:8081/oauth/token/public_key
-      AUTH_SERVER_URL: http://localhost:8081/o/check_api_key/
+      AUTH_JWT_PUBLICKEYURL: http://ego-api:8081/oauth/token/public_key
+      AUTH_SERVER_URL: http://ego-api:8081/o/check_api_key/
       AUTH_SERVER_CLIENTID: song
       AUTH_SERVER_TOKENNAME: apiKey
       AUTH_SERVER_CLIENTSECRET: songsecret
       AUTH_SERVER_SCOPE_STUDY_PREFIX: song.
       AUTH_SERVER_SCOPE_STUDY_SUFFIX: .WRITE
       AUTH_SERVER_SCOPE_SYSTEM: song.WRITE
-      SCORE_URL: http://localhost:8087
+      SCORE_URL: http://score:8087
       SCORE_CLIENTCREDENTIALS_ID: adminId
       SCORE_CLIENTCREDENTIALS_SECRET: adminSecret
-      SCORE_CLIENTCREDENTIALS_TOKENURL: http://localhost:8081/oauth/token
+      SCORE_CLIENTCREDENTIALS_TOKENURL: http://ego-api:8081/oauth/token
       SCORE_CLIENTCREDENTIALS_SYSTEMSCOPE: "score.WRITE"
       MANAGEMENT_SERVER_PORT: 8088
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: password
-      SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:8432/song?stringtype=unspecified
+      SPRING_DATASOURCE_URL: jdbc:postgresql://song-db:5432/song?stringtype=unspecified
       SPRING_FLYWAY_ENABLED: "true"
       SPRING_FLYWAY_LOCATIONS: "classpath:db/migration"
     ports:

--- a/src/main/java/org/cancogenvirusseq/muse/api/model/UploadDTO.java
+++ b/src/main/java/org/cancogenvirusseq/muse/api/model/UploadDTO.java
@@ -18,7 +18,7 @@
 
 package org.cancogenvirusseq.muse.api.model;
 
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.NonNull;
 import lombok.Value;
@@ -31,7 +31,7 @@ public class UploadDTO {
   @NonNull String studyId;
   @NonNull String submitterSampleId;
   @NonNull UploadStatus status;
-  @NonNull List<String> originalFilePair;
+  @NonNull Set<String> originalFilePair;
   UUID analysisId;
   String error;
 

--- a/src/main/java/org/cancogenvirusseq/muse/components/FastaFileProcessor.java
+++ b/src/main/java/org/cancogenvirusseq/muse/components/FastaFileProcessor.java
@@ -16,9 +16,9 @@ public class FastaFileProcessor {
   public static final String FASTA_FILE_EXTENSION = ".fasta";
 
   /**
-   * Processing submission files into a map of isolate filename => SubmissionFile
+   * Processing submission files into a map of isolateFilename => SubmissionFile
    *
-   * @param fastaFile
+   * @param submissionUpload - submissionUpload to be processed
    * @return concurrent hashmap of isolate filename => SubmissionFile
    */
   public static ConcurrentHashMap<String, SubmissionFile> processFileStrContent(

--- a/src/main/java/org/cancogenvirusseq/muse/components/FastaFileProcessor.java
+++ b/src/main/java/org/cancogenvirusseq/muse/components/FastaFileProcessor.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import lombok.SneakyThrows;
 import lombok.val;
 import org.cancogenvirusseq.muse.model.SubmissionFile;
+import org.cancogenvirusseq.muse.model.SubmissionUpload;
 
 public class FastaFileProcessor {
   public static final String FASTA_TYPE = "FASTA";
@@ -20,10 +21,11 @@ public class FastaFileProcessor {
    * @param fastaFile
    * @return concurrent hashmap of isolate filename => SubmissionFile
    */
-  public static ConcurrentHashMap<String, SubmissionFile> processFileStrContent(String fastaFile) {
+  public static ConcurrentHashMap<String, SubmissionFile> processFileStrContent(
+      SubmissionUpload submissionUpload) {
     val isolateToSubmissionFile = new ConcurrentHashMap<String, SubmissionFile>();
 
-    Arrays.stream(fastaFile.split("(?=>)"))
+    Arrays.stream(submissionUpload.getContent().split("(?=>)"))
         .filter(sampleData -> sampleData != null && !sampleData.trim().equals(""))
         .forEach(
             fc -> {
@@ -40,6 +42,7 @@ public class FastaFileProcessor {
                       .content(fc)
                       .dataType(FASTA_TYPE)
                       .fileType(FASTA_TYPE)
+                      .submittedFileName(submissionUpload.getFilename())
                       .build();
 
               isolateToSubmissionFile.put(fastaHeaderOpt.get(), submissionFile);

--- a/src/main/java/org/cancogenvirusseq/muse/components/FastaFileProcessor.java
+++ b/src/main/java/org/cancogenvirusseq/muse/components/FastaFileProcessor.java
@@ -14,6 +14,12 @@ public class FastaFileProcessor {
   public static final String FASTA_TYPE = "FASTA";
   public static final String FASTA_FILE_EXTENSION = ".fasta";
 
+  /**
+   * Processing submission files into a map of isolate filename => SubmissionFile
+   *
+   * @param fastaFile
+   * @return concurrent hashmap of isolate filename => SubmissionFile
+   */
   public static ConcurrentHashMap<String, SubmissionFile> processFileStrContent(String fastaFile) {
     val isolateToSubmissionFile = new ConcurrentHashMap<String, SubmissionFile>();
 

--- a/src/main/java/org/cancogenvirusseq/muse/components/PayloadFileMapper.java
+++ b/src/main/java/org/cancogenvirusseq/muse/components/PayloadFileMapper.java
@@ -77,7 +77,7 @@ public class PayloadFileMapper {
       acc.getRecordsMapped()
           .add(
               new SubmissionRequest(
-                  payload, submissionBundle.getRecordsFileName(), sampleFileName, submissionFile));
+                  payload, submissionFile, submissionBundle.getOriginalFileNames()));
 
       return acc;
     };

--- a/src/main/java/org/cancogenvirusseq/muse/components/PayloadFileMapper.java
+++ b/src/main/java/org/cancogenvirusseq/muse/components/PayloadFileMapper.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -77,7 +79,13 @@ public class PayloadFileMapper {
       acc.getRecordsMapped()
           .add(
               new SubmissionRequest(
-                  payload, submissionFile, submissionBundle.getOriginalFileNames()));
+                  payload,
+                  submissionFile,
+                  Stream.concat(
+                          submissionBundle.getOriginalFileNames().stream()
+                              .filter(filename -> filename.endsWith(".tsv")),
+                          Stream.of(submissionFile.getSubmittedFileName()))
+                      .collect(Collectors.toSet())));
 
       return acc;
     };

--- a/src/main/java/org/cancogenvirusseq/muse/model/SubmissionBundle.java
+++ b/src/main/java/org/cancogenvirusseq/muse/model/SubmissionBundle.java
@@ -25,6 +25,11 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
 
+/**
+ * A submission bundle contains the validated records to upload to song, the validated files for
+ * score, and the original file names. The bundles is then broken up into a series of
+ * SubmissionRequest(s) by the SubmissionService
+ */
 @Getter
 public class SubmissionBundle {
   private final Set<String> originalFileNames = new HashSet<>();

--- a/src/main/java/org/cancogenvirusseq/muse/model/SubmissionBundle.java
+++ b/src/main/java/org/cancogenvirusseq/muse/model/SubmissionBundle.java
@@ -19,19 +19,15 @@
 package org.cancogenvirusseq.muse.model;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
-import lombok.NonNull;
-import lombok.Setter;
 
 @Getter
 public class SubmissionBundle {
-  @Setter private String recordsFileName;
+  private final Set<String> originalFileNames = new HashSet<>();
   private final ArrayList<Map<String, String>> records = new ArrayList<>();
   private final ConcurrentHashMap<String, SubmissionFile> files = new ConcurrentHashMap<>();
-
-  public SubmissionBundle(@NonNull String recordsFileName) {
-    this.recordsFileName = recordsFileName;
-  }
 }

--- a/src/main/java/org/cancogenvirusseq/muse/model/SubmissionEvent.java
+++ b/src/main/java/org/cancogenvirusseq/muse/model/SubmissionEvent.java
@@ -25,6 +25,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
 
+/** Event type used to emit from the SubmissionService to the SongScoreService */
 @Data
 @Builder
 @AllArgsConstructor

--- a/src/main/java/org/cancogenvirusseq/muse/model/SubmissionFile.java
+++ b/src/main/java/org/cancogenvirusseq/muse/model/SubmissionFile.java
@@ -13,4 +13,5 @@ public class SubmissionFile {
   String dataType;
   String fileType;
   String fileAccess = "open";
+  String submittedFileName;
 }

--- a/src/main/java/org/cancogenvirusseq/muse/model/SubmissionFile.java
+++ b/src/main/java/org/cancogenvirusseq/muse/model/SubmissionFile.java
@@ -3,6 +3,7 @@ package org.cancogenvirusseq.muse.model;
 import lombok.Builder;
 import lombok.Value;
 
+/** The object type that is ultimately uploaded to SCORE */
 @Value
 @Builder
 public class SubmissionFile {

--- a/src/main/java/org/cancogenvirusseq/muse/model/SubmissionRequest.java
+++ b/src/main/java/org/cancogenvirusseq/muse/model/SubmissionRequest.java
@@ -23,6 +23,10 @@ import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * A SubmissionRequest represents a pair of record and submission files, plus the filenames from
+ * which they were extracted
+ */
 @Getter
 @AllArgsConstructor
 public class SubmissionRequest {

--- a/src/main/java/org/cancogenvirusseq/muse/model/SubmissionRequest.java
+++ b/src/main/java/org/cancogenvirusseq/muse/model/SubmissionRequest.java
@@ -19,6 +19,7 @@
 package org.cancogenvirusseq.muse.model;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -26,7 +27,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class SubmissionRequest {
   private final ObjectNode record;
-  private final String recordFilename;
-  private final String sampleFilename;
   private final SubmissionFile submissionFile;
+  private final Set<String> originalFileNames;
 }

--- a/src/main/java/org/cancogenvirusseq/muse/model/SubmissionUpload.java
+++ b/src/main/java/org/cancogenvirusseq/muse/model/SubmissionUpload.java
@@ -21,6 +21,10 @@ package org.cancogenvirusseq.muse.model;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * Class containing the raw upload object from a submission with the content read out into a string,
+ * original filename and type captured here as well
+ */
 @Getter
 @AllArgsConstructor
 public class SubmissionUpload {

--- a/src/main/java/org/cancogenvirusseq/muse/model/SubmissionUpload.java
+++ b/src/main/java/org/cancogenvirusseq/muse/model/SubmissionUpload.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.cancogenvirusseq.muse.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SubmissionUpload {
+  private final String filename;
+  private final String type;
+  private final String content;
+}

--- a/src/main/java/org/cancogenvirusseq/muse/repository/model/Upload.java
+++ b/src/main/java/org/cancogenvirusseq/muse/repository/model/Upload.java
@@ -21,7 +21,7 @@ package org.cancogenvirusseq.muse.repository.model;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.time.OffsetDateTime;
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.*;
 import org.springframework.data.annotation.Id;
@@ -48,7 +48,7 @@ public class Upload {
 
   @NonNull private UploadStatus status;
 
-  @NonNull private List<String> originalFilePair;
+  @NonNull private Set<String> originalFilePair;
 
   private UUID analysisId;
 

--- a/src/main/java/org/cancogenvirusseq/muse/service/SongScoreService.java
+++ b/src/main/java/org/cancogenvirusseq/muse/service/SongScoreService.java
@@ -3,7 +3,6 @@ package org.cancogenvirusseq.muse.service;
 import static org.cancogenvirusseq.muse.utils.AnalysisPayloadUtils.getFirstSubmitterSampleId;
 import static org.cancogenvirusseq.muse.utils.AnalysisPayloadUtils.getStudyId;
 
-import java.util.List;
 import java.util.UUID;
 import javax.annotation.PostConstruct;
 import lombok.Getter;
@@ -80,7 +79,7 @@ public class SongScoreService {
                           .submissionId(submissionEvent.getSubmissionId())
                           .userId(submissionEvent.getUserId())
                           .status(UploadStatus.QUEUED)
-                          .originalFilePair(List.of(r.getRecordFilename(), r.getSampleFilename()))
+                          .originalFilePair(r.getOriginalFileNames())
                           .build();
 
                   log.debug(r.getRecord().toPrettyString());

--- a/src/main/java/org/cancogenvirusseq/muse/service/SubmissionService.java
+++ b/src/main/java/org/cancogenvirusseq/muse/service/SubmissionService.java
@@ -27,8 +27,10 @@ import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
-import lombok.*;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.cancogenvirusseq.muse.api.model.SubmissionCreateResponse;
 import org.cancogenvirusseq.muse.components.PayloadFileMapper;
 import org.cancogenvirusseq.muse.components.TsvParser;
@@ -36,6 +38,7 @@ import org.cancogenvirusseq.muse.exceptions.submission.SubmissionFilesException;
 import org.cancogenvirusseq.muse.model.SubmissionBundle;
 import org.cancogenvirusseq.muse.model.SubmissionEvent;
 import org.cancogenvirusseq.muse.model.SubmissionRequest;
+import org.cancogenvirusseq.muse.model.SubmissionUpload;
 import org.cancogenvirusseq.muse.repository.SubmissionRepository;
 import org.cancogenvirusseq.muse.repository.model.Submission;
 import org.springframework.core.io.buffer.DataBuffer;
@@ -217,17 +220,9 @@ public class SubmissionService {
         break;
       case "fasta":
         // process the submitted file into upload ready files
-        submissionBundle.getFiles().putAll(processFileStrContent(submissionUpload.getContent()));
+        submissionBundle.getFiles().putAll(processFileStrContent(submissionUpload));
         break;
     }
     return submissionBundle;
-  }
-
-  @Getter
-  @AllArgsConstructor
-  private static class SubmissionUpload {
-    private final String filename;
-    private final String type;
-    private final String content;
   }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,7 +17,7 @@ codecConfig:
   maxHeadersSize: 16384
 
 upload.backpressure:
-  highTide: 10
+  highTide: 5
   lowTide: 2
 
 postgres:
@@ -33,8 +33,8 @@ songScoreClient:
   clientId: adminId
   clientSecret: adminSecret
   tokenUrl: http://localhost:8081/oauth/token
-  retryMaxAttempts: 2
-  retryDelaySec: 5
+  retryMaxAttempts: 3
+  retryDelaySec: 10
 
 auth:
   jwtPublicKeyUrl: "http://localhost:8081/oauth/token/public_key"

--- a/src/test/java/org/cancogenvirusseq/muse/service/UploadServiceTest.java
+++ b/src/test/java/org/cancogenvirusseq/muse/service/UploadServiceTest.java
@@ -19,9 +19,9 @@
 package org.cancogenvirusseq.muse.service;
 
 import java.time.OffsetDateTime;
+import java.util.Set;
 import java.util.UUID;
 import lombok.val;
-import org.assertj.core.util.Lists;
 import org.cancogenvirusseq.muse.repository.model.Upload;
 import org.cancogenvirusseq.muse.repository.model.UploadStatus;
 import org.junit.jupiter.api.Test;
@@ -80,7 +80,7 @@ public class UploadServiceTest {
     return Upload.builder()
         .uploadId(UUID.randomUUID())
         .createdAt(OffsetDateTime.now())
-        .originalFilePair(Lists.emptyList())
+        .originalFilePair(Set.of())
         .status(UploadStatus.QUEUED)
         .studyId("MUSE-TEST")
         .submissionId(submissionId)


### PR DESCRIPTION
* Original filenames was still not working correctly, this should now resolve it (note: needs tests)
* Current default values for back-pressure related were leading to failures in dev, lowered them, looks to have done the trick, will need to update helm chart and values to fine tune further
* Docker compose should not need host network mode, also token expiry now set to max possible value (max int) - @jaserud  feel free to revert the compose networking changes if they don't work for you right now, we can address it later
* Added comments in a few places for personal sanity