### PR TITLE
Fix gzip newlines

### DIFF
--- a/src/main/java/org/cancogenvirusseq/muse/api/ApiDefinition.java
+++ b/src/main/java/org/cancogenvirusseq/muse/api/ApiDefinition.java
@@ -230,5 +230,5 @@ public interface ApiDefinition {
       value = "/download/gzip",
       produces = MediaType.APPLICATION_OCTET_STREAM_VALUE,
       method = RequestMethod.GET)
-  ResponseEntity<Flux<DataBuffer>> downloadGzip(@Valid @RequestParam List<UUID> objectIds);
+  ResponseEntity<Mono<DataBuffer>> downloadGzip(@Valid @RequestParam List<UUID> objectIds);
 }

--- a/src/main/java/org/cancogenvirusseq/muse/service/DownloadsService.java
+++ b/src/main/java/org/cancogenvirusseq/muse/service/DownloadsService.java
@@ -63,8 +63,7 @@ public class DownloadsService {
         .concatMap(
             analysisFileResponse -> {
               val objectId = analysisFileResponse.getObjectId();
-              return Flux.concat(
-                  newLineBuffer(), songScoreClient.downloadObject(objectId), newLineBuffer());
+              return Flux.concat(songScoreClient.downloadObject(objectId), newLineBuffer());
             })
         .onErrorMap(t -> !(t instanceof MuseBaseException), t -> new UnknownException());
   }

--- a/src/main/java/org/cancogenvirusseq/muse/service/DownloadsService.java
+++ b/src/main/java/org/cancogenvirusseq/muse/service/DownloadsService.java
@@ -70,7 +70,7 @@ public class DownloadsService {
 
   private static Flux<DataBuffer> newLineBuffer() {
     val buffer = new DefaultDataBufferFactory().allocateBuffer(4);
-    val newLIne = "\r\n";
+    val newLIne = "\n";
     buffer.write(newLIne.getBytes());
     return Flux.just(buffer);
   }

--- a/src/main/java/org/cancogenvirusseq/muse/service/DownloadsService.java
+++ b/src/main/java/org/cancogenvirusseq/muse/service/DownloadsService.java
@@ -43,8 +43,6 @@ public class DownloadsService {
 
   final SongScoreClient songScoreClient;
 
-  private static final Flux<DataBuffer> NEW_LINE_BUFFER_FLUX = newLineBuffer();
-
   public Flux<DataBuffer> download(List<UUID> objectIds) {
     return Flux.fromIterable(objectIds)
         .flatMap(this::fetchDownloadInfoFromSong)
@@ -66,16 +64,14 @@ public class DownloadsService {
             analysisFileResponse -> {
               val objectId = analysisFileResponse.getObjectId();
               return Flux.concat(
-                  NEW_LINE_BUFFER_FLUX,
-                  songScoreClient.downloadObject(objectId),
-                  NEW_LINE_BUFFER_FLUX);
+                  newLineBuffer(), songScoreClient.downloadObject(objectId), newLineBuffer());
             })
         .onErrorMap(t -> !(t instanceof MuseBaseException), t -> new UnknownException());
   }
 
   private static Flux<DataBuffer> newLineBuffer() {
-    val buffer = new DefaultDataBufferFactory().allocateBuffer();
-    val newLIne = "\n";
+    val buffer = new DefaultDataBufferFactory().allocateBuffer(4);
+    val newLIne = "\r\n";
     buffer.write(newLIne.getBytes());
     return Flux.just(buffer);
   }


### PR DESCRIPTION
changes:
- create new line buffer each time, so mutating buffer doesn't affect other newline buffers
- reduce Flux<buffer> from download gzip endpoint into one DataBuffer, gziping the stream is resulting in incorrect/inefficient/inconsistent file sizes (file size inside gzip is equal to file size outside which doesn't make sense for a compressed file)
e.g downloading same objects-ids from dev:
![image](https://user-images.githubusercontent.com/34698315/116161764-64351a00-a6c2-11eb-9e91-416f8a46e5f4.png)

after fix:
![image](https://user-images.githubusercontent.com/34698315/116161787-6d25eb80-a6c2-11eb-8905-c4386e1e3f01.png)

