### PR TITLE
update README.md to include GitHub Maven registry usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,24 @@
 Molecular Upload Submission sErvice
 
 # DEV environment setup
-A docker-compose setup is available with all required services for MUSE in `./compose`.
+This app depends on [Overture Aria](https://github.com/overture-stack/aria), which is distributed from the GitHub Maven registry. You may need to create a "[Personal Access Token (classic)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)", and to define it in a `settings.xml` file, in order for MUSE to compile. 
+
+The following template can be used like `mvnw -s settings.xml clean package`, etc.
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<settings>
+    <servers>
+        <server>
+            <id>github</id>
+            <username>GitHub_UserName</username>
+            <password>Personal_Access_Token_Here</password>
+        </server>
+    </servers>
+</settings>
+```
+
+A docker-compose setup is also available with all required services for MUSE in `./compose`.
 
 ## Run:
  Move to compose folder: `cd compose`


### PR DESCRIPTION
Seeks to clarify how to build MUSE now that it relies on GitHub's registry to get Aria .. or at least set a base placeholder for further instructions.