### PR TITLE
#66 Fix Bug : Clinical submitters facing issue with UTF-8-BOM Input files

### DIFF
--- a/src/main/java/org/cancogenvirusseq/muse/service/SubmissionService.java
+++ b/src/main/java/org/cancogenvirusseq/muse/service/SubmissionService.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
@@ -213,18 +214,32 @@ public class SubmissionService {
   }
 
   private static final Function<Flux<DataBuffer>, Mono<String>> fileContentToString =
-      (Flux<DataBuffer> content) ->
-          content
-              .map(
-                  dataBuffer -> {
-                    val bytes = new byte[dataBuffer.readableByteCount()];
-                    dataBuffer.read(bytes);
-                    DataBufferUtils.release(dataBuffer);
+      (Flux<DataBuffer> content) -> {
+        AtomicBoolean firstChunk = new AtomicBoolean(true);
 
-                    return new String(bytes, StandardCharsets.UTF_8);
-                  })
-              .reduce(new StringBuilder(), StringBuilder::append)
-              .map(StringBuilder::toString);
+        return content
+            .map(
+                dataBuffer -> {
+                  val bytes = new byte[dataBuffer.readableByteCount()];
+                  dataBuffer.read(bytes);
+                  DataBufferUtils.release(dataBuffer);
+
+                  if (firstChunk.getAndSet(false)) {
+                    // Check for UTF-8 BOM
+                    if (bytes.length >= 3 &&
+                        (bytes[0] & 0xFF) == 0xEF &&
+                        (bytes[1] & 0xFF) == 0xBB &&
+                        (bytes[2] & 0xFF) == 0xBF) {
+                      // Strip first 3 bytes
+                      return new String(bytes, 3, bytes.length - 3, StandardCharsets.UTF_8);
+                    }
+                  }
+
+                  return new String(bytes, StandardCharsets.UTF_8);
+                })
+            .reduce(new StringBuilder(), StringBuilder::append)
+            .map(StringBuilder::toString);
+      };
 
   private static final Function<Tuple2<String, FilePart>, Flux<DataBuffer>>
       getContentFromMaybeZipped =


### PR DESCRIPTION
# Description
This PR fixes an issue preventing BOM encoded TSV files from being uploaded due to unrecognized headers.

## Issues related:
- https://github.com/virusseq/roadmap/issues/66